### PR TITLE
Allow arbitrary version commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,33 @@ This GitHub Action automatically tags master with the version in a file. Right n
 
 ## Getting the version from a file
 
-This action allows you to customize the command used to get the version to tag. By default, the following command is used:
+This action allows the end user to customize the command used to get the version before setting the tag. By default, the following command is used:
 ```bash
 cat mix.exs \
     | grep --line-buffer "version: " \
     | grep --extended-regexp --only-matching "\"[-0-9\.\+a-zA-Z]+\"" \
     | grep --extended-regexp --only-matching "[-0-9\.\+a-zA-Z]+"
 ```
-It is used to read the version defined in `mix.exs`, a file used in elixir projects. Of course, a mode simple command can be used instead by setting the `VERSION_COMMAND` environment variable.
+It is used to read the version defined in `mix.exs`, a file used in elixir projects. 
+
+A custom command can be used by setting the `VERSION_COMMAND` environment variable. For example if your version was in a `VERSION` file in the root of this repository, one could use something like the following in their GitHub Actions yaml file to use this Action:
+```yaml
+name: Tagging master using mix.exs
+on: 
+  push:
+    branches:
+      - master 
+jobs:
+  build:
+    name: Tag master using mix.exs
+    runs-on: ubuntu-18.04    
+    steps:
+    - name: Checkout master
+      uses: actions/checkout@master
+    - name: Tag master depending on the value in mix.exs
+      uses: djordon/git-autotag-action@v0.3.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION_COMMAND: cat VERSION
+```
+When using something like the above in your repo, updating the contents in the `VERSION` file would auto tag your repo when there was a push to the `master` branch.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Automatic Repo Tagging GitHub Action
 
 This GitHub Action automatically tags master with the version in a file. Right now, only the version in the `mix.exs` is supported, but I'll add more as the need arises.
+
+
+## Getting the version from a file
+
+This action allows you to customize the command used to get the version to tag. By default, the following command is used:
+```bash
+cat mix.exs \
+    | grep --line-buffer "version: " \
+    | grep --extended-regexp --only-matching "\"[-0-9\.\+a-zA-Z]+\"" \
+    | grep --extended-regexp --only-matching "[-0-9\.\+a-zA-Z]+"
+```
+It is used to read the version defined in `mix.exs`, a file used in elixir projects. Of course, a mode simple command can be used instead by setting the `VERSION_COMMAND` environment variable.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ VERSION=$(eval ${VERSION_COMMAND:-$DEFAULT_VERSION})
 
 if [ -z $VERSION ]
 then 
-    echo "Version command yielded an empty version. Exiting"
+    echo "VERSION_COMMAND yielded an empty version. Exiting"
     exit 0
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,12 @@ DEFAULT_VERSION='cat mix.exs \
 
 VERSION=$(eval ${VERSION_COMMAND:-$DEFAULT_VERSION})
 
+if [ -z $VERSION ]
+then 
+    echo "Version command yielded an empty version. Exiting"
+    exit 0
+fi
+
 TAG=$(git tag | grep --extended-regexp "^v${VERSION}$")
 
 if [ ! -z $TAG ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-VERSION=$(cat mix.exs \
+DEFAULT_VERSION='cat mix.exs \
     | grep --line-buffer "version: " \
     | grep --extended-regexp --only-matching "\"[-0-9\.\+a-zA-Z]+\"" \
-    | grep --extended-regexp --only-matching "[-0-9\.\+a-zA-Z]+")
+    | grep --extended-regexp --only-matching "[-0-9\.\+a-zA-Z]+"'
+
+VERSION=$(eval ${VERSION_COMMAND:-$DEFAULT_VERSION})
 
 TAG=$(git tag | grep --extended-regexp "^v${VERSION}$")
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tags.Mixfile do
   def project do
     [
       app: :tags,
-      version: "0.2.0"
+      version: "0.3.0"
     ]
   end
 end


### PR DESCRIPTION
This PR 
- Allows one to specify an arbitrary bash command when deciding what set as the version.
- Updates the README. Probably contains a typo or two.