### PR TITLE
Exit status 1 on bad command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,15 +8,15 @@ DEFAULT_VERSION='cat mix.exs
 VERSION=$(eval ${VERSION_COMMAND:-$DEFAULT_VERSION})
 
 if [ -z $VERSION ]
-then 
-    echo "VERSION_COMMAND yielded an empty version. Exiting"
-    exit 0
+then
+    echo "VERSION_COMMAND yielded an empty version. That's probably unexpected. Exiting with status 1."
+    exit 1
 fi
 
 TAG=$(git tag | grep --extended-regexp "^v${VERSION}$")
 
 if [ ! -z $TAG ]
-then 
+then
     echo "Tag $TAG already exists. Exiting"
     exit 0
 fi

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tags.Mixfile do
   def project do
     [
       app: :tags,
-      version: "0.3.0"
+      version: "0.4.0"
     ]
   end
 end


### PR DESCRIPTION
This PR changes the exit status from 0 to 1 when the `VERSION_COMMAND` yields an empty string.